### PR TITLE
ci(sonar): repointa para host válido (sonarqube.rankmyapp.com)

### DIFF
--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -17,14 +17,14 @@ jobs:
     - name: SonarQube Scan
       uses: kitabisa/sonarqube-action@v1.2.0
       with:
-        host: ${{ secrets.SONARQUBE_HOST_DEV }}
-        login: ${{ secrets.SONARQUBE_TOKEN_DEV }}
+        host: ${{ secrets.SONARQUBE_HOST }}
+        login: ${{ secrets.SONARQUBE_TOKEN }}
     
     - name: Quality Gate
       uses: sonarsource/sonarqube-quality-gate-action@master
       env:
         timeout-minutes: 5
-        SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN_DEV }}
+        SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
         
   build:
     name: Build


### PR DESCRIPTION
Repointa o Sonar do host dev quebrado (cert fake) para `sonarqube.rankmyapp.com` (cert válido).

- `SONARQUBE_HOST_DEV`/`SONARQUBE_TOKEN_DEV` -> `SONARQUBE_HOST`/`SONARQUBE_TOKEN`
- URL hardcoded `sonarqube.apps.rmadev...` -> `sonarqube.rankmyapp.com`

Correção em massa: o host dev parou de servir cert válido e quebrou todos os scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)